### PR TITLE
group_membersが同じグループ、同じユーザに複数できないようにブロックする #16

### DIFF
--- a/app/models/group_member.rb
+++ b/app/models/group_member.rb
@@ -3,4 +3,6 @@ class GroupMember < ActiveRecord::Base
 	belongs_to :group
 
 	enum role: {operator: 0, admin: 1}
+
+	validates :user_id, :uniqueness => {:scope => :group_id}
 end

--- a/db/migrate/20160320112726_add_index_uniqueness_to_group_membres.rb
+++ b/db/migrate/20160320112726_add_index_uniqueness_to_group_membres.rb
@@ -1,0 +1,5 @@
+class AddIndexUniquenessToGroupMembres < ActiveRecord::Migration
+  def change
+  	add_index :group_members, [:user_id, :group_id], :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160316095509) do
+ActiveRecord::Schema.define(version: 20160320112726) do
 
   create_table "group_members", force: :cascade do |t|
     t.integer  "user_id",                null: false
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 20160316095509) do
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
   end
+
+  add_index "group_members", ["user_id", "group_id"], name: "index_group_members_on_user_id_and_group_id", unique: true
 
   create_table "groups", force: :cascade do |t|
     t.string   "name",        null: false


### PR DESCRIPTION
- group_membersテーブルにユニーク制約を追加
- GroupMembersモデルにバリデーションを追加

@ms2sato
